### PR TITLE
Upgrade to Dolibarr 13.0.4

### DIFF
--- a/images/13.0/php7.3-apache-amd64/.dockertags
+++ b/images/13.0/php7.3-apache-amd64/.dockertags
@@ -1,1 +1,1 @@
-13.0.2-apache 13.0-apache apache 13.0.2 13.0 latest 
+13.0.4-apache 13.0-apache apache 13.0.4 13.0 latest 

--- a/images/13.0/php7.3-apache-amd64/Dockerfile
+++ b/images/13.0/php7.3-apache-amd64/Dockerfile
@@ -98,7 +98,7 @@ ENV DOLI_AUTO_CONFIGURE=1 \
 	PHP_MAX_EXECUTION_TIME=300
 
 # Build time env var
-ARG DOLI_VERSION=13.0.2
+ARG DOLI_VERSION=13.0.4
 
 # Get Dolibarr
 ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip

--- a/images/13.0/php7.3-apache-i386/.dockertags
+++ b/images/13.0/php7.3-apache-i386/.dockertags
@@ -1,1 +1,1 @@
-13.0.2-apache 13.0-apache apache 13.0.2 13.0 latest 
+13.0.4-apache 13.0-apache apache 13.0.4 13.0 latest 

--- a/images/13.0/php7.3-apache-i386/Dockerfile
+++ b/images/13.0/php7.3-apache-i386/Dockerfile
@@ -98,7 +98,7 @@ ENV DOLI_AUTO_CONFIGURE=1 \
 	PHP_MAX_EXECUTION_TIME=300
 
 # Build time env var
-ARG DOLI_VERSION=13.0.2
+ARG DOLI_VERSION=13.0.4
 
 # Get Dolibarr
 ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip

--- a/images/13.0/php7.3-fpm-alpine-amd64/.dockertags
+++ b/images/13.0/php7.3-fpm-alpine-amd64/.dockertags
@@ -1,1 +1,1 @@
-13.0.2-fpm-alpine 13.0-fpm-alpine fpm-alpine 
+13.0.4-fpm-alpine 13.0-fpm-alpine fpm-alpine 

--- a/images/13.0/php7.3-fpm-alpine-amd64/Dockerfile
+++ b/images/13.0/php7.3-fpm-alpine-amd64/Dockerfile
@@ -108,7 +108,7 @@ ENV DOLI_AUTO_CONFIGURE=1 \
 	PHP_MAX_EXECUTION_TIME=300
 
 # Build time env var
-ARG DOLI_VERSION=13.0.2
+ARG DOLI_VERSION=13.0.4
 
 # Get Dolibarr
 ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip

--- a/images/13.0/php7.3-fpm-alpine-i386/.dockertags
+++ b/images/13.0/php7.3-fpm-alpine-i386/.dockertags
@@ -1,1 +1,1 @@
-13.0.2-fpm-alpine 13.0-fpm-alpine fpm-alpine 
+13.0.4-fpm-alpine 13.0-fpm-alpine fpm-alpine 

--- a/images/13.0/php7.3-fpm-alpine-i386/Dockerfile
+++ b/images/13.0/php7.3-fpm-alpine-i386/Dockerfile
@@ -108,7 +108,7 @@ ENV DOLI_AUTO_CONFIGURE=1 \
 	PHP_MAX_EXECUTION_TIME=300
 
 # Build time env var
-ARG DOLI_VERSION=13.0.2
+ARG DOLI_VERSION=13.0.4
 
 # Get Dolibarr
 ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip

--- a/images/13.0/php7.3-fpm-amd64/.dockertags
+++ b/images/13.0/php7.3-fpm-amd64/.dockertags
@@ -1,1 +1,1 @@
-13.0.2-fpm 13.0-fpm fpm 
+13.0.4-fpm 13.0-fpm fpm 

--- a/images/13.0/php7.3-fpm-amd64/Dockerfile
+++ b/images/13.0/php7.3-fpm-amd64/Dockerfile
@@ -98,7 +98,7 @@ ENV DOLI_AUTO_CONFIGURE=1 \
 	PHP_MAX_EXECUTION_TIME=300
 
 # Build time env var
-ARG DOLI_VERSION=13.0.2
+ARG DOLI_VERSION=13.0.4
 
 # Get Dolibarr
 ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip

--- a/images/13.0/php7.3-fpm-i386/.dockertags
+++ b/images/13.0/php7.3-fpm-i386/.dockertags
@@ -1,1 +1,1 @@
-13.0.2-fpm 13.0-fpm fpm 
+13.0.4-fpm 13.0-fpm fpm 

--- a/images/13.0/php7.3-fpm-i386/Dockerfile
+++ b/images/13.0/php7.3-fpm-i386/Dockerfile
@@ -98,7 +98,7 @@ ENV DOLI_AUTO_CONFIGURE=1 \
 	PHP_MAX_EXECUTION_TIME=300
 
 # Build time env var
-ARG DOLI_VERSION=13.0.2
+ARG DOLI_VERSION=13.0.4
 
 # Get Dolibarr
 ADD https://github.com/Dolibarr/dolibarr/archive/${DOLI_VERSION}.zip /tmp/dolibarr.zip


### PR DESCRIPTION
Hello Monogramm team,
I have seen that your docker is based of the 13.0.2 version of dolibarr, a new version has been released since your last commit, I have upgraded the tags and Docker variables to match this new version ! 
(I used  your last commit as an example :) ) 

Thank you for your work ! 