### PR TITLE
:pushpin: Use a more precise tag

### DIFF
--- a/images/13.0/php7.3-apache-amd64/Dockerfile
+++ b/images/13.0/php7.3-apache-amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/php:7.3-apache
+FROM amd64/php:7.3-apache-buster
 
 # Install the packages we need
 # Install the PHP extensions we need

--- a/images/13.0/php7.3-apache-i386/Dockerfile
+++ b/images/13.0/php7.3-apache-i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/php:7.3-apache
+FROM i386/php:7.3-apache-buster
 
 # Install the packages we need
 # Install the PHP extensions we need

--- a/images/13.0/php7.3-fpm-amd64/Dockerfile
+++ b/images/13.0/php7.3-fpm-amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/php:7.3-fpm
+FROM amd64/php:7.3-fpm-buster
 
 # Install the packages we need
 # Install the PHP extensions we need

--- a/images/13.0/php7.3-fpm-i386/Dockerfile
+++ b/images/13.0/php7.3-fpm-i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/php:7.3-fpm
+FROM i386/php:7.3-fpm-buster
 
 # Install the packages we need
 # Install the PHP extensions we need

--- a/images/14.0/php7.3-apache-amd64/Dockerfile
+++ b/images/14.0/php7.3-apache-amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/php:7.3-apache
+FROM amd64/php:7.3-apache-buster
 
 # Install the packages we need
 # Install the PHP extensions we need

--- a/images/14.0/php7.3-apache-i386/Dockerfile
+++ b/images/14.0/php7.3-apache-i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/php:7.3-apache
+FROM i386/php:7.3-apache-buster
 
 # Install the packages we need
 # Install the PHP extensions we need

--- a/images/14.0/php7.3-fpm-amd64/Dockerfile
+++ b/images/14.0/php7.3-fpm-amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/php:7.3-fpm
+FROM amd64/php:7.3-fpm-buster
 
 # Install the packages we need
 # Install the PHP extensions we need

--- a/images/14.0/php7.3-fpm-i386/Dockerfile
+++ b/images/14.0/php7.3-fpm-i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/php:7.3-fpm
+FROM i386/php:7.3-fpm-buster
 
 # Install the packages we need
 # Install the PHP extensions we need


### PR DESCRIPTION
This PR changes the base image for Dolibarr 13.0.x and 14.0.x Debian-based images to ensure Debian Buster is used. Here's why:

I built an image using the sources in `images/14.0/php7.3-apache-amd64/` and used it to upgrade my company's Dolibarr instance, which was using the image `monogramm/docker-dolibarr:13.0-apache`. Everything seemed to work, except the LDAP connection (TLS errors). Changing `DOLI_VERSION` in the Dockerfile by other 14.0.x or 13.0.x Dolibarr versions didn't solve the issue.

After some research I found that the base image used for the Dockerfile, `amd64/php:7.3-apache`, used to be based on Debian Buster when `monogramm/docker-dolibarr:13.0-apache` was built 4 months ago, but the image is now based on Debian Bullseye, so there are major updates for many packets, one of them must have broken the LDAP connection.

Replacing `FROM amd64/php:7.3-apache` by `FROM amd64/php:7.3-apache-buster` solved the issue for our instance, everything seems to work for now.
