### PR TITLE
fix(github workflow): Add Dolibarr version 14.0 to github matrix workflow

### DIFF
--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['10.0', '11.0', '12.0', '13.0']
+        version: ['10.0', '11.0', '12.0', '13.0', '14.0']
         php: ['7.3']
         archi: ['amd64']
         variant: ['apache', 'fpm', 'fpm-alpine']


### PR DESCRIPTION
Added version 14 of dolibarr to make the version available on docker hub
